### PR TITLE
Feature/ItemManager

### DIFF
--- a/Client/Assets/Resources/Data/ItemData.json
+++ b/Client/Assets/Resources/Data/ItemData.json
@@ -2,23 +2,31 @@
   "items": [
     {
       "id": 0,
-      "name": "",
+      "name": "날카로운 칼",
+      "itemType": 0,
+      "price": 700,
+      "prefab": "Weapon"
     },
     {
       "id": 1,
-      "name": "",
+      "name": "강철 갑옷",
+      "itemType": 1,
+      "price": 1000,
+      "prefab": "Armor"
     },
     {
       "id": 2,
-      "name": "",
+      "name": "아뮬렛",
+      "itemType": 2,
+      "price": 600,
+      "prefab": "Accessories"
     },
     {
       "id": 3,
-      "name": "",
-    },
-    {
-      "id": 4,
-      "name": "",
+      "name": "힐링포션",
+      "itemType": 3,
+      "price": 300,
+      "prefab": "Potion"
     }
   ]
 }

--- a/Client/Assets/Resources/Prefabs/Items.meta
+++ b/Client/Assets/Resources/Prefabs/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b9b80b6d8306aa44af0f7e8eeeb01bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/Items/Accessories.prefab
+++ b/Client/Assets/Resources/Prefabs/Items/Accessories.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8415371082229604446
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8092791946395169950}
+  - component: {fileID: 6721443017887449274}
+  - component: {fileID: 1890139976989532381}
+  - component: {fileID: 420256736306594269}
+  m_Layer: 0
+  m_Name: Accessories
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8092791946395169950
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8415371082229604446}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.7322, y: -0.3183, z: 0}
+  m_LocalScale: {x: 1.9261092, y: 1.715503, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6721443017887449274
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8415371082229604446}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 84ef55e7d2b9749429e16cff7eac1e24, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.92, y: 1.92}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1890139976989532381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8415371082229604446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b41b2e33840249f49a057e01da072763, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &420256736306594269
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8415371082229604446}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.48, y: 0.48}
+    newSize: {x: 1.92, y: 1.92}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.48, y: 0.48}
+  m_EdgeRadius: 0

--- a/Client/Assets/Resources/Prefabs/Items/Accessories.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/Items/Accessories.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81568595a0b3f4845813a790847f020a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/Items/Armor.prefab
+++ b/Client/Assets/Resources/Prefabs/Items/Armor.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8287461668378295253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1708980019312764358}
+  - component: {fileID: 2821302528736876464}
+  - component: {fileID: 1868190881793586883}
+  - component: {fileID: 3278238811880190802}
+  m_Layer: 0
+  m_Name: Armor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1708980019312764358
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8287461668378295253}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.54, y: -0.26, z: 0}
+  m_LocalScale: {x: 0.54748476, y: 0.49487376, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2821302528736876464
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8287461668378295253}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d359cffafe45e0e4c82527e85234799b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1868190881793586883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8287461668378295253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b41b2e33840249f49a057e01da072763, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &3278238811880190802
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8287461668378295253}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.92, y: 1.92}
+    newSize: {x: 2.56, y: 2.56}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.92, y: 1.92}
+  m_EdgeRadius: 0

--- a/Client/Assets/Resources/Prefabs/Items/Armor.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/Items/Armor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 362f90a43bce157468be878b6dc4dfa0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/Items/Potion.prefab
+++ b/Client/Assets/Resources/Prefabs/Items/Potion.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &910090912725829721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 340817945106755610}
+  - component: {fileID: 7936337234024298801}
+  - component: {fileID: 3034221159928174773}
+  - component: {fileID: -2348850673353281264}
+  m_Layer: 0
+  m_Name: Potion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &340817945106755610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910090912725829721}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.9019, y: -0.4183, z: 0.06383294}
+  m_LocalScale: {x: 1.7998, y: 1.5472, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7936337234024298801
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910090912725829721}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: e84dcbc357f47e047b76d8a39292e93b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.48, y: 0.48}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &3034221159928174773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910090912725829721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b41b2e33840249f49a057e01da072763, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &-2348850673353281264
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910090912725829721}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.48, y: 0.48}
+    newSize: {x: 0.48, y: 0.48}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.48, y: 0.48}
+  m_EdgeRadius: 0

--- a/Client/Assets/Resources/Prefabs/Items/Potion.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/Items/Potion.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ef8f064789149c40a8d974f69430e47
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/Items/Weapon.prefab
+++ b/Client/Assets/Resources/Prefabs/Items/Weapon.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9119088822306630376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 37266519361609950}
+  - component: {fileID: 2822486074740252526}
+  - component: {fileID: 5411346951105154388}
+  - component: {fileID: 9208275035027023098}
+  m_Layer: 0
+  m_Name: Weapon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &37266519361609950
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9119088822306630376}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.7004, y: -0.2894, z: 0}
+  m_LocalScale: {x: 0.7979172, y: 0.8585121, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2822486074740252526
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9119088822306630376}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 131449278, guid: 6eb16e372762d6b4cb708c44ebfab931, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.92, y: 1.92}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &5411346951105154388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9119088822306630376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b41b2e33840249f49a057e01da072763, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &9208275035027023098
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9119088822306630376}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1.92, y: 1.92}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Client/Assets/Resources/Prefabs/Items/Weapon.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/Items/Weapon.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a15b9e8ab7b0bcd4b8b64804f5d47a71
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Controllers/ItemController.cs
+++ b/Client/Assets/Scripts/Controllers/ItemController.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using UnityEngine;
+
+public class ItemController : MonoBehaviour
+{
+    private void Start()
+    {
+        StartCoroutine(TimeOverItemDestroy());
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.tag == "Player")
+        {
+            ItemManager.Instance.LootItem(gameObject);
+        }
+    }
+
+    IEnumerator TimeOverItemDestroy()
+    {
+        yield return new WaitForSeconds(5f);
+        ItemManager.Instance.DestroyItem(gameObject);
+    }
+}

--- a/Client/Assets/Scripts/Controllers/ItemController.cs.meta
+++ b/Client/Assets/Scripts/Controllers/ItemController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b41b2e33840249f49a057e01da072763
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Controllers/MonsterController.cs
+++ b/Client/Assets/Scripts/Controllers/MonsterController.cs
@@ -36,6 +36,7 @@ public class MonsterController : MonoBehaviour
     private void Awake()
     {
         _player = GameObject.FindGameObjectWithTag("Player");
+        MonsterDeathEvent += ItemManager.Instance.CreateItem;
     }
 
     private void Start()

--- a/Client/Assets/Scripts/DataFormat/Item.cs
+++ b/Client/Assets/Scripts/DataFormat/Item.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Generic;
+using static Define;
 
 [Serializable]
 public class Item
 {
     public int id;
     public string name;
+    public ItemType itemType;
+    public int price;
+    public string prefab;
 }
 
 [Serializable]

--- a/Client/Assets/Scripts/Managers/DataManager.cs
+++ b/Client/Assets/Scripts/Managers/DataManager.cs
@@ -7,11 +7,11 @@ public interface ILoader<Key, Value>
     Dictionary<Key, Value> MakeDict();
 }
 
-public class DataManager
+public class DataManager : CustomSingleton<DataManager>
 {
     public Dictionary<int, Item> ItemDict { get; private set; } = new Dictionary<int, Item>();
 
-    public void Init()
+    private void Awake()
     {
         ItemDict = LoadJson<ItemData, int, Item>("ItemData").MakeDict();
     }

--- a/Client/Assets/Scripts/Managers/ItemManager.cs
+++ b/Client/Assets/Scripts/Managers/ItemManager.cs
@@ -1,0 +1,58 @@
+using Assets.Scripts.Managers;
+using System.Collections.Generic;
+using UnityEngine;
+using static Define;
+
+public class ItemManager : CustomSingleton<ItemManager> 
+{
+    private Queue<Item> _itemQueue = new Queue<Item>();
+
+    private const int MIN_ITEM_COUNT = 0;
+    private const int MAX_ITEM_COUNT = (int)ItemType.MaxCount;
+
+    public void CreateItem(Vector3 monsterPos)
+    {
+        int randNum = Random.Range(MIN_ITEM_COUNT, MAX_ITEM_COUNT);
+        Item createdItem = DataManager.Instance.ItemDict[randNum];
+
+        if (createdItem == null)
+            return;
+
+        string createdItemPrefab = createdItem.prefab;
+        GameObject itemGameObject = ResourceManager.Instance.Instantiate($"Items/{createdItemPrefab}");
+
+        if (itemGameObject == null)
+            return;
+
+        itemGameObject.transform.position = monsterPos;
+    }
+
+    public void LootItem(GameObject itemGameObject)
+    {
+        Dictionary<int, Item> itemDict = DataManager.Instance.ItemDict;
+        string lootItemName = itemGameObject.name;
+
+        Item lootItem = null;
+        foreach(Item item in itemDict.Values)
+        {
+            if (lootItemName.Equals(item.prefab))
+                lootItem = item;
+        }
+
+        if (lootItem == null)
+            return;
+
+        SoundManager.Instance.Play("coin", Sound.Effect);
+        _itemQueue.Enqueue(lootItem);
+        
+        DestroyItem(itemGameObject);
+    }
+
+    public void DestroyItem(GameObject itemGameObject) 
+    {
+        if (itemGameObject == null)
+            return;
+
+        ResourceManager.Instance.Destroy(itemGameObject);
+    }
+}

--- a/Client/Assets/Scripts/Managers/ItemManager.cs.meta
+++ b/Client/Assets/Scripts/Managers/ItemManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12c990f8dbdf20241a2b96c45a8ac9d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Managers/SoundManager.cs
+++ b/Client/Assets/Scripts/Managers/SoundManager.cs
@@ -7,7 +7,7 @@ public class SoundManager : CustomSingleton<SoundManager>
     AudioSource[] _audioSources = new AudioSource[(int)Define.Sound.MaxCount];
     Dictionary<string, AudioClip> _audioClips = new Dictionary<string, AudioClip>();
 
-    private void Start()
+    private void Awake()
     {
         string[] soundNames = System.Enum.GetNames(typeof(Define.Sound));
         for (int i = 0; i < soundNames.Length - 1; i++)

--- a/Client/Assets/Scripts/Packet/ClientPacketManager.cs
+++ b/Client/Assets/Scripts/Packet/ClientPacketManager.cs
@@ -37,8 +37,10 @@ class PacketManager
 		if (_makeFunc.TryGetValue(id, out func))
 		{
 			IPacket packet = func.Invoke(session, buffer);
-
-			HandlePacket(session, packet);
+			if (onRecvCallback != null)
+				onRecvCallback.Invoke(session, packet);
+			else
+				HandlePacket(session, packet);
 		}
 	}
 

--- a/Client/Assets/Scripts/Utils/Define.cs
+++ b/Client/Assets/Scripts/Utils/Define.cs
@@ -6,4 +6,13 @@ public class Define
         Effect,
         MaxCount
     }
+
+    public enum ItemType
+    {
+        Weapon,
+        Armor,
+        Accessories,
+        Potion,
+        MaxCount,
+    }
 }

--- a/Server/PacketGenerator/PacketFormat.cs
+++ b/Server/PacketGenerator/PacketFormat.cs
@@ -45,8 +45,10 @@ class PacketManager
 		if (_makeFunc.TryGetValue(id, out func))
 		{{
 			IPacket packet = func.Invoke(session, buffer);
-
-			HandlePacket(session, packet);
+			if (onRecvCallback != null)
+				onRecvCallback.Invoke(session, packet);
+			else
+				HandlePacket(session, packet);
 		}}
 	}}
 


### PR DESCRIPTION
# ItemManager
- 몬스터 처치 시 아이템 드랍(생성)
  - 생성된 아이템 Player가 줍지 않으면 5초 후에 Destroy
- Player와 Item 충돌 시 줍기(Loot) 기능
  - Item은 Destroy 처리
  - Item 정보를 ItemManager에 있는 ItemQueue에 저장
  - 유저가 아이템 줏을 시 이펙트(Effect) 사운드 실행


# 차 후 보완사항(개발 소요)
- 탐험 완료 후 ItemQueue에 있는 데이터를 서버에 전송 후 저장
- 생성된 아이템을 줍지 않으면 시간에 맞춰서 깜빡이는 UI 이벤트